### PR TITLE
Email composer send shortcut

### DIFF
--- a/packages/frontend/components/MiddlePanel/EmailViewer/EmailComposer.tsx
+++ b/packages/frontend/components/MiddlePanel/EmailViewer/EmailComposer.tsx
@@ -2,8 +2,7 @@ import {
   Send, 
   X, 
   Paperclip, 
-  Save,
-  ArrowLeft
+  Save
 } from 'lucide-react'
 import { useState, useCallback, useEffect } from 'react'
 import { Button } from '../../ui/button'
@@ -12,6 +11,7 @@ import { useToast } from '../../ui/use-toast'
 import { EmailTiptapEditor } from './EmailTiptapEditor'
 import RecipientChipsInput from './RecipientChipsInput'
 import { ApiService } from '../../../../backend/api/apiService'
+import { useKeyboardShortcuts, getSendShortcutText } from './handlers/useKeyboardShortcuts'
 
 const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
   let binary = ''
@@ -45,6 +45,7 @@ export function EmailComposer({ onBack, onSendComplete, replyTo }: EmailComposer
   const [signature, setSignature] = useState<string>('')
   const [loadingSignature, setLoadingSignature] = useState(false)
   const { toast } = useToast()
+  const sendShortcutText = getSendShortcutText()
 
   // Fetch signature when component mounts (only for new emails, not replies)
   useEffect(() => {
@@ -273,6 +274,13 @@ export function EmailComposer({ onBack, onSendComplete, replyTo }: EmailComposer
     setAttachments(prev => prev.filter((_, i) => i !== index))
   }, [])
 
+  // Enable keyboard shortcut (Ctrl+Enter / Cmd+Enter) when form is valid and not sending
+  const canSend = parseRecipients(form.to).length > 0 && form.subject && !isContentEmpty(form.body) && !sending
+  useKeyboardShortcuts({
+    onSend: handleSend,
+    enabled: canSend
+  })
+
   return (
     <div className="h-full flex flex-col bg-card">
       {/* Email Form */}
@@ -389,13 +397,12 @@ export function EmailComposer({ onBack, onSendComplete, replyTo }: EmailComposer
                 variant="default"
                 size="sm"
                 onClick={handleSend}
-                disabled={
-                  sending || parseRecipients(form.to).length === 0 || !form.subject || isContentEmpty(form.body)
-                }
+                disabled={!canSend}
                 className="flex-shrink-0 w-auto px-4 bg-primary hover:bg-primary/90 text-primary-foreground"
               >
                 <Send className="h-4 w-4 mr-2" />
                 {sending ? 'Sending...' : 'Send'}
+                <span className="ml-2 text-xs opacity-70">{sendShortcutText}</span>
               </Button>
               <Button
                 variant="secondary"

--- a/packages/frontend/components/MiddlePanel/EmailViewer/handlers/useKeyboardShortcuts.ts
+++ b/packages/frontend/components/MiddlePanel/EmailViewer/handlers/useKeyboardShortcuts.ts
@@ -1,0 +1,32 @@
+import { useEffect, useCallback } from 'react'
+
+interface UseKeyboardShortcutsProps {
+  onSend: () => void
+  enabled: boolean
+}
+
+export function useKeyboardShortcuts({ onSend, enabled }: UseKeyboardShortcutsProps) {
+  const handleKeyDown = useCallback((event: KeyboardEvent) => {
+    if (!enabled) return
+
+    // Ctrl+Enter or Cmd+Enter to send
+    if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+      event.preventDefault()
+      onSend()
+    }
+  }, [onSend, enabled])
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [handleKeyDown])
+}
+
+// Helper to get the keyboard shortcut display text based on platform
+export function getSendShortcutText(): string {
+  // Check if running on macOS
+  const isMac = typeof navigator !== 'undefined' && navigator.platform.toUpperCase().indexOf('MAC') >= 0
+  return isMac ? '⌘↵' : 'Ctrl+↵'
+}


### PR DESCRIPTION
Add Ctrl+Enter (or Cmd+Enter) keybind to send email and display the shortcut on the send button.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf9e692e-2b3a-42ea-9ba7-b9634153778d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bf9e692e-2b3a-42ea-9ba7-b9634153778d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

