### PR TITLE
Enable streaming for Claude Skills API

### DIFF
--- a/packages/frontend/assistant/ClaudeRuntimeProvider/handlers/processStreamEvents.ts
+++ b/packages/frontend/assistant/ClaudeRuntimeProvider/handlers/processStreamEvents.ts
@@ -170,11 +170,60 @@ export async function* processStreamEvents({
           contentParts.push({ type: "text", text: `❌ Error: ${errorMessage}` });
           yield { content: contentParts, status: { type: "incomplete", reason: "error" } };
           return; // Stop processing further events
+        } else if (evt.type === "file-update") {
+          // Handle Skills file updates (live preview during generation)
+          const { fileType, fileId, fileName, downloadUrl, isIntermediate } = evt;
+
+          console.log(`[Skills] File update: ${fileType} - ${fileName} (fileId: ${fileId}, path: ${downloadUrl}, intermediate: ${isIntermediate})`)
+
+          // Dispatch update event based on file type
+          if (fileType === 'pptx') {
+            window.dispatchEvent(new CustomEvent('powerpoint-file-update', {
+              detail: { fileType, fileId, fileName, downloadUrl, isIntermediate }
+            }));
+          } else if (fileType === 'docx') {
+            window.dispatchEvent(new CustomEvent('word-file-update', {
+              detail: { fileType, fileId, fileName, downloadUrl, isIntermediate }
+            }));
+          } else if (fileType === 'xlsx') {
+            window.dispatchEvent(new CustomEvent('excel-file-update', {
+              detail: { fileType, fileId, fileName, downloadUrl, isIntermediate }
+            }));
+          } else if (fileType === 'pdf') {
+            window.dispatchEvent(new CustomEvent('pdf-file-update', {
+              detail: { fileType, fileId, fileName, downloadUrl, isIntermediate }
+            }));
+          }
+
+          // For the first update, also dispatch assistant-file-created to auto-open
+          if (isIntermediate) {
+            console.log('[Skills] Dispatching assistant-file-created event for live preview')
+            window.dispatchEvent(new CustomEvent('assistant-file-created', {
+              detail: {
+                result: {
+                  file_info: {
+                    file_id: fileId,
+                    file_name: fileName,
+                    file_path: downloadUrl
+                  }
+                }
+              }
+            }));
+          }
+
+          // Add a text message for first update only
+          if (isIntermediate) {
+            contentParts.push({
+              type: "text",
+              text: `🔄 Generating ${fileType.toUpperCase()} file: ${fileName} (live preview)...`
+            });
+          }
+          shouldYield = true;
         } else if (evt.type === "file-generated") {
-          // Handle Skills-generated files (PowerPoint, Word, Excel, PDF)
+          // Handle Skills-generated files (PowerPoint, Word, Excel, PDF) - final version
           const { fileType, fileId, fileName, downloadUrl } = evt;
 
-          console.log(`[Skills] File generated: ${fileType} - ${fileName} (fileId: ${fileId}, path: ${downloadUrl})`)
+          console.log(`[Skills] File generated (final): ${fileType} - ${fileName} (fileId: ${fileId}, path: ${downloadUrl})`)
 
           // Dispatch event based on file type (for viewers already open)
           if (fileType === 'pptx') {
@@ -195,7 +244,7 @@ export async function* processStreamEvents({
             }));
           }
 
-          // Also dispatch assistant-file-created to trigger auto-open
+          // Also dispatch assistant-file-created to trigger auto-open (if not already opened by update)
           console.log('[Skills] Dispatching assistant-file-created event to auto-open file')
           window.dispatchEvent(new CustomEvent('assistant-file-created', {
             detail: {

--- a/packages/frontend/components/MiddlePanel/PowerPointViewer/PowerPointViewer.tsx
+++ b/packages/frontend/components/MiddlePanel/PowerPointViewer/PowerPointViewer.tsx
@@ -741,7 +741,66 @@ export function PowerPointViewer({ file, userInfo, onSaveComplete }: PowerPointV
     }
   }, [slides, currentSlideIndex, selectedElementId])
 
-  // Listen for Skills-generated files (new file-based workflow)
+  // Listen for Skills file updates (live preview during generation)
+  useEffect(() => {
+    const updateHandler = async (event: CustomEvent) => {
+      const detail = event?.detail || {}
+      const { fileId, fileName, fileType, isIntermediate } = detail
+
+      console.log('[PowerPointViewer] Received powerpoint-file-update event:', detail)
+
+      if (fileType !== 'pptx') {
+        console.log('[PowerPointViewer] Ignoring non-pptx file:', fileType)
+        return
+      }
+
+      if (!fileId || !fileName) {
+        console.warn('[PowerPointViewer] File-update event missing fileId or fileName')
+        return
+      }
+
+      console.log('[PowerPointViewer] Downloading updated file:', fileName)
+
+      try {
+        // Download file from S3
+        const result = await ApiService.downloadFromS3(fileId, fileName)
+        if (!result.success || !result.blob) {
+          throw new Error('Failed to download presentation update')
+        }
+
+        // Parse the PPTX file
+        const parsedSlides = await parsePptxFile(result.blob)
+
+        // Replace current slides with updated ones
+        setSlides(parsedSlides)
+        setCurrentSlideIndex(0)
+        setSelectedElementId(null)
+        setHasUnsavedChanges(true)
+
+        // Save to history
+        pushToHistory(parsedSlides, 0)
+        setUndoAvailable(canUndo())
+        setRedoAvailable(canRedo())
+
+        if (isIntermediate) {
+          toast({
+            title: 'Live preview updated',
+            description: 'Presentation is being generated in real-time',
+            variant: 'default'
+          })
+        }
+      } catch (error) {
+        console.error('Error loading file update:', error)
+      }
+    }
+
+    window.addEventListener('powerpoint-file-update', updateHandler as EventListener)
+    return () => {
+      window.removeEventListener('powerpoint-file-update', updateHandler as EventListener)
+    }
+  }, [])
+
+  // Listen for Skills-generated files (final version)
   useEffect(() => {
     const handler = async (event: CustomEvent) => {
       const detail = event?.detail || {}
@@ -783,7 +842,7 @@ export function PowerPointViewer({ file, userInfo, onSaveComplete }: PowerPointV
         setRedoAvailable(canRedo())
 
         toast({
-          title: 'Presentation generated',
+          title: 'Presentation completed',
           description: 'Your presentation has been created using Claude Skills',
           variant: 'default'
         })

--- a/packages/pages/api/assistant/claude-skills-stream/index.ts
+++ b/packages/pages/api/assistant/claude-skills-stream/index.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import Anthropic from '@anthropic-ai/sdk'
-import type { SkillsStreamRequestBody, FileGeneratedEvent } from './types'
+import type { SkillsStreamRequestBody, FileGeneratedEvent, FileUpdateEvent } from './types'
 import { extractFileIds } from './handlers/extractFileIds'
 import { downloadFromContainer } from './handlers/downloadFromContainer'
 import { uploadToS3 } from './utils/uploadToS3'
@@ -114,6 +114,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     let response: any
     let fullTextContent = ''
+    const contentBlocks: any[] = []
+    const processedFileIds = new Set<string>()
+    let currentBlockIndex = -1
 
     try {
       const stream = await messagesApi.create({
@@ -162,10 +165,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
           case 'content_block_start':
             // New content block started
+            currentBlockIndex++
+            contentBlocks[currentBlockIndex] = {
+              type: event.content_block?.type,
+              index: event.index ?? currentBlockIndex
+            }
+            if (event.content_block) {
+              Object.assign(contentBlocks[currentBlockIndex], event.content_block)
+            }
             break
 
           case 'content_block_delta':
-            // Streaming text delta
+            // Streaming content delta
             if (event.delta?.type === 'text_delta' && event.delta?.text) {
               const text = event.delta.text
               fullTextContent += text
@@ -173,11 +184,42 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 type: 'text-delta',
                 text: text
               })
+
+              // Update content block
+              const blockIdx = event.index ?? currentBlockIndex
+              if (contentBlocks[blockIdx]) {
+                if (!contentBlocks[blockIdx].text) {
+                  contentBlocks[blockIdx].text = ''
+                }
+                contentBlocks[blockIdx].text += text
+              }
             }
             break
 
           case 'content_block_stop':
-            // Content block ended
+            // Content block ended - check for files
+            const blockIdx = event.index ?? currentBlockIndex
+            const block = contentBlocks[blockIdx]
+
+            if (block) {
+              console.log('[Skills] Content block stopped:', JSON.stringify(block, null, 2))
+
+              // Try to extract file IDs from this block
+              const tempResponse = { content: [block] }
+              const fileIds = extractFileIds(tempResponse)
+
+              if (fileIds.length > 0) {
+                console.log('[Skills] Found file IDs in intermediate block:', fileIds)
+
+                // Process files immediately (live updates)
+                for (const fileId of fileIds) {
+                  if (!processedFileIds.has(fileId)) {
+                    processedFileIds.add(fileId)
+                    await processGeneratedFiles([fileId], client, token, send, true) // true = isIntermediate
+                  }
+                }
+              }
+            }
             break
 
           case 'message_delta':
@@ -196,6 +238,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         response = (stream as any).finalMessage || (stream as any).message
       }
 
+      // If response still doesn't have content, reconstruct from blocks
+      if (!response?.content && contentBlocks.length > 0) {
+        response = { content: contentBlocks }
+      }
+
     } finally {
       clearInterval(keepAlive)
       clearInterval(progress)
@@ -205,14 +252,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     console.log('[Skills] Full response:', JSON.stringify(response, null, 2))
     console.log('[Skills] Response content blocks:', response?.content?.map((b: any) => ({ type: b.type, hasContent: !!b.content })))
 
-    // Check for generated files
+    // Check for generated files (final check, might have already been processed during streaming)
     const fileIds = extractFileIds(response)
-    console.log('[Skills] Extracted file IDs:', fileIds)
+    console.log('[Skills] Extracted file IDs from final response:', fileIds)
 
-    if (fileIds.length > 0) {
-      console.log('[Skills] Processing generated files:', fileIds)
-      // Process files
-      await processGeneratedFiles(fileIds, client, token, send)
+    // Filter out already-processed files
+    const newFileIds = fileIds.filter(id => !processedFileIds.has(id))
+
+    if (newFileIds.length > 0) {
+      console.log('[Skills] Processing remaining files:', newFileIds)
+      // Process files (final, not intermediate)
+      await processGeneratedFiles(newFileIds, client, token, send, false)
+    } else if (fileIds.length > 0) {
+      console.log('[Skills] All files were already processed during streaming')
     } else {
       console.log('[Skills] No file IDs found in response')
     }
@@ -267,15 +319,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
 /**
  * Process generated files: download from container and upload to S3
+ * @param isIntermediate - If true, sends file-update events for live preview. If false, sends file-generated events for final version.
  */
 async function processGeneratedFiles(
   fileIds: string[],
   client: Anthropic,
   authToken: string,
-  send: (event: any) => void
+  send: (event: any) => void,
+  isIntermediate: boolean = false
 ) {
   for (const fileId of fileIds) {
-    console.log(`[Skills] Processing file ${fileId}`)
+    console.log(`[Skills] Processing file ${fileId} (intermediate: ${isIntermediate})`)
     try {
       // Download file from container
       console.log(`[Skills] Downloading file ${fileId} from container`)
@@ -306,15 +360,30 @@ async function processGeneratedFiles(
       console.log(`[Skills] Upload result:`, uploadResult)
 
       if (uploadResult.ok && uploadResult.file_info) {
-        const event: FileGeneratedEvent = {
-          type: 'file-generated',
-          fileType,
-          fileId: uploadResult.file_info.file_id || fileId,
-          fileName: uploadResult.file_info.file_name,
-          downloadUrl: uploadResult.file_info.file_path
+        if (isIntermediate) {
+          // Send file-update event for live preview
+          const event: FileUpdateEvent = {
+            type: 'file-update',
+            fileType,
+            fileId: uploadResult.file_info.file_id || fileId,
+            fileName: uploadResult.file_info.file_name,
+            downloadUrl: uploadResult.file_info.file_path,
+            isIntermediate: true
+          }
+          console.log(`[Skills] Sending file-update event (intermediate):`, event)
+          send(event)
+        } else {
+          // Send file-generated event for final version
+          const event: FileGeneratedEvent = {
+            type: 'file-generated',
+            fileType,
+            fileId: uploadResult.file_info.file_id || fileId,
+            fileName: uploadResult.file_info.file_name,
+            downloadUrl: uploadResult.file_info.file_path
+          }
+          console.log(`[Skills] Sending file-generated event (final):`, event)
+          send(event)
         }
-        console.log(`[Skills] Sending file-generated event:`, event)
-        send(event)
       } else {
         send({
           type: 'error',

--- a/packages/pages/api/assistant/claude-skills-stream/types/index.ts
+++ b/packages/pages/api/assistant/claude-skills-stream/types/index.ts
@@ -20,6 +20,15 @@ export interface FileGeneratedEvent {
   downloadUrl?: string
 }
 
+export interface FileUpdateEvent {
+  type: 'file-update'
+  fileType: 'pptx' | 'docx' | 'xlsx' | 'pdf'
+  fileId: string
+  fileName: string
+  downloadUrl?: string
+  isIntermediate: boolean // true for progressive updates, false for final
+}
+
 export interface FileMetadata {
   id: string
   filename: string


### PR DESCRIPTION
- Add stream: true parameter to messagesApi.create() call
- Process streaming events (content_block_delta) in real-time
- Forward text deltas to frontend immediately as they arrive
- Maintain backward compatibility with file generation workflow
- Improve user experience with real-time text streaming instead of waiting for complete response