### PR TITLE
Test suite corrections

### DIFF
--- a/packages/tests/langgraph/processStreamChunk.test.ts
+++ b/packages/tests/langgraph/processStreamChunk.test.ts
@@ -24,6 +24,7 @@ function buildParams(overrides: Partial<Parameters<typeof processStreamChunk>[0]
     processedAiMessages: new Set<string>(),
     processedToolCalls: new Set<string>(),
     currentToolExecution: null,
+    toolExecutionMap: new Map<string, any>(),
     send,
     ...overrides,
   }


### PR DESCRIPTION
Fix failing `processStreamChunk` tests by providing the required `toolExecutionMap` parameter.

The `processStreamChunk` function expects a `toolExecutionMap` parameter, but the test's `buildParams` helper was not supplying it, causing an error when `toolExecutionMap.set()` was called on an undefined value. Adding `new Map<string, any>()` resolves this.

---
<a href="https://cursor.com/background-agent?bcId=bc-07cdc515-64d9-4931-ba8d-eb3d97adaa6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-07cdc515-64d9-4931-ba8d-eb3d97adaa6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

