### PR TITLE
Optimize admin tab API calls to load only relevant data

### DIFF
--- a/packages/frontend/components/AdminContent/AdminContent.tsx
+++ b/packages/frontend/components/AdminContent/AdminContent.tsx
@@ -78,14 +78,24 @@ export function AdminContent({ activeTab }: AdminContentProps) {
   }, [])
 
   useEffect(() => {
-    if ((activeTab === 'admin-analytics-overview' || activeTab === 'admin-visitors' || activeTab === 'admin-conversations') && !visitorLoading && !loginLoading && !scopesLoading && !conversationsLoading && !usersLoading && !dashboardVisitLoading && !workspaceVisitLoading) {
+    // Overview tab - loads only aggregate stats needed for overview
+    if (activeTab === 'admin-analytics-overview' && !visitorLoading && !loginLoading && !conversationsLoading && !dashboardVisitLoading && !workspaceVisitLoading) {
       loadVisitorData(analyticsDays)
       loadLoginData(analyticsDays)
-      loadScopesAnalytics()
       loadConversationsAnalytics(analyticsDays, conversationUserFilter)
-      loadConversationUsers(analyticsDays)
       loadDashboardVisitStats()
       loadWorkspaceVisitStats()
+    }
+
+    // Visitors tab - only loads visitor-specific data
+    if (activeTab === 'admin-visitors' && !visitorLoading) {
+      loadVisitorData(analyticsDays)
+    }
+
+    // Conversations tab - only loads conversation-specific data
+    if (activeTab === 'admin-conversations' && !conversationsLoading && !usersLoading) {
+      loadConversationsAnalytics(analyticsDays, conversationUserFilter)
+      loadConversationUsers(analyticsDays)
     }
 
     if (activeTab === 'admin-filetypes' && !fileTypeLoading) {


### PR DESCRIPTION
Previously, opening any of the analytics-related admin tabs (overview, visitors, or conversations) would trigger all API calls for all three tabs, leading to unnecessary data fetching.

Changes:
- Overview tab: now only loads visitor stats, login stats, conversation stats, dashboard visit stats, and workspace visit stats (removed scopesAnalytics and conversationUsers)
- Visitors tab: now only loads visitor data
- Conversations tab: now only loads conversation analytics and conversation users

This optimization significantly reduces API load and improves performance when navigating admin tabs.