### PR TITLE
Add 'Open File' button to pending changes and refresh file sidebar

### DIFF
--- a/packages/frontend/components/MiddlePanel/CanvasViewer/DrawioAITool.tsx
+++ b/packages/frontend/components/MiddlePanel/CanvasViewer/DrawioAITool.tsx
@@ -81,11 +81,14 @@ export const DrawioAITool: React.FC<DrawioAIToolProps> = (props) => {
     };
     window.dispatchEvent(new CustomEvent('drawio-ai-response', { detail: payload }));
     setApplied(true);
-    
+
     // Immediately notify that this change has been resolved
     if (changeIdRef.current) {
       window.dispatchEvent(new CustomEvent('ai-change-resolved', { detail: { id: changeIdRef.current } }));
     }
+
+    // Trigger file sidebar refresh to update file list
+    window.dispatchEvent(new CustomEvent('file-sidebar-refresh'));
   };
 
   const handleReject = () => {
@@ -114,7 +117,8 @@ export const DrawioAITool: React.FC<DrawioAIToolProps> = (props) => {
         detail: {
           id: changeId,
           type: 'diagram',
-          description: diagramName || 'Diagram'
+          description: diagramName || 'Diagram',
+          filePath: fileUrl
         }
       }));
       

--- a/packages/frontend/components/RightPanel/composer/Composer.tsx
+++ b/packages/frontend/components/RightPanel/composer/Composer.tsx
@@ -130,9 +130,10 @@ interface ComposerProps {
   onAttachmentPayload: (fileId: string, payload: { fileData: string; mimeType: string }) => void;
   onSend?: () => void;
   onFileView?: (file: FileSystemItem) => void;
-  pendingChanges: Array<{ id: string; type: string; description: string }>;
+  pendingChanges: Array<{ id: string; type: string; description: string; filePath?: string }>;
   onAcceptAll: () => void;
   onRejectAll: () => void;
+  onOpenFile?: (change: { id: string; type: string; description: string; filePath?: string }) => void;
   // Fallback message buffer for context calculation when runtime messages aren't available
   messageBuffer?: any[] | null;
   // Tab ID for updating tab title on first message
@@ -145,7 +146,7 @@ interface ComposerProps {
   onSendNextQueued: () => void;
 }
 
-export const Composer: FC<ComposerProps> = ({ attachedFiles, attachedEmails, onFileAttach, onFileRemove, onEmailAttach, onEmailRemove, userInfo, toolPreferences, onUpdateToolPreferences, attachmentPayloads, onAttachmentPayload, onSend, onFileView, pendingChanges, onAcceptAll, onRejectAll, messageBuffer, assistantTabId, queuedMessages, onQueueMessage, onRemoveQueuedMessage, onMoveQueuedMessageToFront, onSendNextQueued }) => {
+export const Composer: FC<ComposerProps> = ({ attachedFiles, attachedEmails, onFileAttach, onFileRemove, onEmailAttach, onEmailRemove, userInfo, toolPreferences, onUpdateToolPreferences, attachmentPayloads, onAttachmentPayload, onSend, onFileView, pendingChanges, onAcceptAll, onRejectAll, onOpenFile, messageBuffer, assistantTabId, queuedMessages, onQueueMessage, onRemoveQueuedMessage, onMoveQueuedMessageToFront, onSendNextQueued }) => {
   const composer = useComposerRuntime();
   const threadRuntime = useThreadRuntime();
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
@@ -346,6 +347,7 @@ export const Composer: FC<ComposerProps> = ({ attachedFiles, attachedEmails, onF
           pendingChanges={pendingChanges}
           onAcceptAll={onAcceptAll}
           onRejectAll={onRejectAll}
+          onOpenFile={onOpenFile}
         />
 
         {/* Display editing queued message indicator */}

--- a/packages/frontend/components/RightPanel/composer/components/AIToolCard.tsx
+++ b/packages/frontend/components/RightPanel/composer/components/AIToolCard.tsx
@@ -55,7 +55,7 @@ export const AIToolCard: React.FC<AIToolCardProps> = ({
   const changeIdRef = useRef<string>('');
   const Icon = config.icon;
 
-  // Resolve display name from localStorage if file extensions provided
+  // Resolve display name and file path from localStorage if file extensions provided
   const resolvedDisplayName = React.useMemo(() => {
     if (!config.fileExtensions || !config.fileExtensions.length) {
       return config.displayName;
@@ -63,8 +63,8 @@ export const AIToolCard: React.FC<AIToolCardProps> = ({
 
     try {
       const attachedFiles = JSON.parse(localStorage.getItem('pendingAttachments') || '[]');
-      const matchingFile = attachedFiles.find((file: any) => 
-        file.fileName && config.fileExtensions!.some(ext => 
+      const matchingFile = attachedFiles.find((file: any) =>
+        file.fileName && config.fileExtensions!.some(ext =>
           file.fileName.toLowerCase().endsWith(ext.toLowerCase())
         )
       );
@@ -77,6 +77,28 @@ export const AIToolCard: React.FC<AIToolCardProps> = ({
 
     return config.displayName;
   }, [config.displayName, config.fileExtensions]);
+
+  const resolvedFilePath = React.useMemo(() => {
+    if (!config.fileExtensions || !config.fileExtensions.length) {
+      return undefined;
+    }
+
+    try {
+      const attachedFiles = JSON.parse(localStorage.getItem('pendingAttachments') || '[]');
+      const matchingFile = attachedFiles.find((file: any) =>
+        file.fileName && config.fileExtensions!.some(ext =>
+          file.fileName.toLowerCase().endsWith(ext.toLowerCase())
+        )
+      );
+      if (matchingFile) {
+        return matchingFile.filePath || matchingFile.path;
+      }
+    } catch (error) {
+      console.warn('Could not get attached file path:', error);
+    }
+
+    return undefined;
+  }, [config.fileExtensions]);
 
   const handleAcceptAll = () => {
     if (applied || rejected) return;
@@ -94,12 +116,15 @@ export const AIToolCard: React.FC<AIToolCardProps> = ({
     }
     
     setApplied(true);
-    
+
     if (changeIdRef.current) {
-      window.dispatchEvent(new CustomEvent('ai-change-resolved', { 
-        detail: { id: changeIdRef.current } 
+      window.dispatchEvent(new CustomEvent('ai-change-resolved', {
+        detail: { id: changeIdRef.current }
       }));
     }
+
+    // Trigger file sidebar refresh to update file list
+    window.dispatchEvent(new CustomEvent('file-sidebar-refresh'));
   };
 
   const handleReject = () => {
@@ -150,7 +175,8 @@ export const AIToolCard: React.FC<AIToolCardProps> = ({
         detail: {
           id: changeId,
           type: config.changeType,
-          description: resolvedDisplayName
+          description: resolvedDisplayName,
+          filePath: resolvedFilePath
         }
       }));
       

--- a/packages/frontend/components/RightPanel/composer/components/pending-changes-bar.tsx
+++ b/packages/frontend/components/RightPanel/composer/components/pending-changes-bar.tsx
@@ -7,6 +7,7 @@ import {
   FileText,
   Table,
   PaintbrushIcon,
+  FolderOpen,
 } from "lucide-react";
 import { Button } from "../../../ui/button";
 
@@ -16,18 +17,21 @@ interface PendingChange {
   id: string;
   type: string;
   description: string;
+  filePath?: string;
 }
 
 interface PendingChangesBarProps {
   pendingChanges: PendingChange[];
   onAcceptAll: () => void;
   onRejectAll: () => void;
+  onOpenFile?: (change: PendingChange) => void;
 }
 
 export const PendingChangesBar: FC<PendingChangesBarProps> = ({
   pendingChanges,
   onAcceptAll,
   onRejectAll,
+  onOpenFile,
 }) => {
   const [isPendingChangesExpanded, setIsPendingChangesExpanded] = useState(false);
 
@@ -97,12 +101,26 @@ export const PendingChangesBar: FC<PendingChangesBarProps> = ({
               {pendingChanges.map((change) => (
                 <div
                   key={change.id}
-                  className="flex items-center gap-2 py-1 px-2 hover:bg-zinc-100 dark:hover:bg-zinc-700 rounded"
+                  className="flex items-center gap-2 py-1 px-2 hover:bg-zinc-100 dark:hover:bg-zinc-700 rounded group"
                 >
                   {getIcon(change.type)}
                   <span className="text-sm text-zinc-700 dark:text-zinc-300 truncate flex-1" title={change.description}>
                     {change.description}
                   </span>
+                  {onOpenFile && (
+                    <Button
+                      size="xs"
+                      variant="ghost"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onOpenFile(change);
+                      }}
+                      className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100 transition-opacity hover:bg-zinc-200 dark:hover:bg-zinc-600"
+                      title="Open file"
+                    >
+                      <FolderOpen className="h-3.5 w-3.5 text-zinc-600 dark:text-zinc-400" strokeWidth={1.5} />
+                    </Button>
+                  )}
                 </div>
               ))}
             </div>

--- a/packages/frontend/components/RightPanel/composer/thread/thread.tsx
+++ b/packages/frontend/components/RightPanel/composer/thread/thread.tsx
@@ -90,7 +90,7 @@ export const Thread: FC<ThreadProps> = ({ userInfo, selectedFile, selectedEmail,
   }, [assistantTabId]);
   const [drawioModalOpen, setDrawioModalOpen] = useState(false);
   const [selectedDrawioFile, setSelectedDrawioFile] = useState<FileSystemItem | null>(null);
-  const [pendingChanges, setPendingChanges] = useState<Array<{ id: string; type: string; description: string }>>([]);
+  const [pendingChanges, setPendingChanges] = useState<Array<{ id: string; type: string; description: string; filePath?: string }>>([]);
   
   // Message queue state
   const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
@@ -872,11 +872,11 @@ export const Thread: FC<ThreadProps> = ({ userInfo, selectedFile, selectedEmail,
   // Track pending changes from AI tools
   useEffect(() => {
     const handleChangeRegistered = (event: CustomEvent) => {
-      const { id, type, description } = event.detail;
+      const { id, type, description, filePath } = event.detail;
       setPendingChanges(prev => {
         // Avoid duplicates
         if (prev.some(c => c.id === id)) return prev;
-        return [...prev, { id, type, description }];
+        return [...prev, { id, type, description, filePath }];
       });
     };
 
@@ -902,6 +902,28 @@ export const Thread: FC<ThreadProps> = ({ userInfo, selectedFile, selectedEmail,
   const handleRejectAll = () => {
     window.dispatchEvent(new CustomEvent('ai-reject-all'));
     setPendingChanges([]);
+  };
+
+  const handleOpenFile = (change: { id: string; type: string; description: string; filePath?: string }) => {
+    // If we have a file path, dispatch workspace-reopen-file event
+    if (change.filePath) {
+      const file = {
+        id: change.filePath,
+        file_id: change.filePath,
+        name: change.description,
+        type: 'file' as const,
+        path: change.filePath,
+      };
+      window.dispatchEvent(new CustomEvent('workspace-reopen-file', {
+        detail: { newFile: file }
+      }));
+    } else {
+      // If no file path, try to find the file by name using a custom event
+      // The workspace can handle finding the file by name
+      window.dispatchEvent(new CustomEvent('workspace-find-and-open-file', {
+        detail: { fileName: change.description }
+      }));
+    }
   };
 
   // Listen for DOCX AI response events
@@ -1164,7 +1186,7 @@ export const Thread: FC<ThreadProps> = ({ userInfo, selectedFile, selectedEmail,
         </ThreadPrimitive.If>
       </ThreadPrimitive.Viewport>
 
-      <Composer 
+      <Composer
         attachedFiles={attachedFiles}
         attachedEmails={attachedEmails}
         onFileAttach={handleFileAttach}
@@ -1180,6 +1202,7 @@ export const Thread: FC<ThreadProps> = ({ userInfo, selectedFile, selectedEmail,
         pendingChanges={pendingChanges}
         onAcceptAll={handleAcceptAll}
         onRejectAll={handleRejectAll}
+        onOpenFile={handleOpenFile}
         messageBuffer={loadedMessagesBuffer}
         assistantTabId={assistantTabId}
         queuedMessages={queuedMessages}

--- a/packages/frontend/pages/Workspaces/Workspaces.tsx
+++ b/packages/frontend/pages/Workspaces/Workspaces.tsx
@@ -1115,7 +1115,37 @@ const Workspaces = (): React.ReactNode => {
     window.addEventListener('file-sidebar-refresh', handler);
     return () => window.removeEventListener('file-sidebar-refresh', handler);
   }, [triggerSidebarRefresh]);
-  
+
+  // Listen for workspace-find-and-open-file events to find and open files by name
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent).detail || {};
+      const { fileName } = detail;
+      if (!fileName) return;
+
+      // Search for the file in the file tree
+      const findFileByName = (items: FileSystemItem[], name: string): FileSystemItem | null => {
+        for (const item of items) {
+          if (item.type === 'file' && item.name === name) {
+            return item;
+          }
+          if (item.type === 'directory' && item.children) {
+            const found = findFileByName(item.children, name);
+            if (found) return found;
+          }
+        }
+        return null;
+      };
+
+      const file = findFileByName(fileTree, fileName);
+      if (file) {
+        openFileInTabCallback(file, activePanelId);
+      }
+    };
+    window.addEventListener('workspace-find-and-open-file', handler as EventListener);
+    return () => window.removeEventListener('workspace-find-and-open-file', handler as EventListener);
+  }, [fileTree, openFileInTabCallback, activePanelId]);
+
   // Load conversations on mount
   useEffect(() => {
     if (userInfo?.username) {


### PR DESCRIPTION
- Add 'Open File' button to each pending change item in the right panel
  - Button appears on hover for each pending change
  - Opens the file in the middle panel when clicked
- Add filePath field to PendingChange interface to track file paths
- Implement file opening functionality:
  - If filePath is available, use workspace-reopen-file event
  - Otherwise, use workspace-find-and-open-file event to search by name
- Add workspace-find-and-open-file event handler in Workspaces.tsx
  - Searches file tree by name and opens matching file
- Fix left panel not refreshing when files are created/modified:
  - Dispatch file-sidebar-refresh event when AI changes are accepted
  - Added to AIToolCard and DrawioAITool accept handlers
- Update ai-change-registered events to include filePath when available
  - Extract file path from localStorage pendingAttachments
  - Include in event detail for AIToolCard and DrawioAITool